### PR TITLE
Feat/#5/custom footer

### DIFF
--- a/apis/blogHome.ts
+++ b/apis/blogHome.ts
@@ -2,7 +2,7 @@ import { isAxiosError } from 'axios';
 
 import { ArticleData } from '@/types/article';
 import { AuthorInfoProps } from '@/types/author';
-import { HeaderProps, subscribeData } from '@/types/blogHeader';
+import { FooterProps, HeaderProps, subscribeData } from '@/types/blogHeader';
 import { BlogImgProps } from '@/types/blogMainImg';
 import { Response } from '@/types/common';
 import { ContentProps } from '@/types/content';
@@ -22,6 +22,18 @@ export const getBlogHeaderInfo = async (blogUrl: string) => {
       return err.response?.data;
     }
     return;
+  }
+};
+
+//블로그 footer 정보 가져오기
+export const getBlogFooterInfo = async (blogUrl: string) => {
+  try {
+    const { data } = await client.get<Response<FooterProps>>(`/api/v2/view/blog/${blogUrl}/footer`);
+    return data;
+  } catch (err) {
+    if (isAxiosError(err)) {
+      return err.response?.data;
+    }
   }
 };
 

--- a/app/[team]/layout.tsx
+++ b/app/[team]/layout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { getBlogHeaderInfo } from '@/apis/blogHome';
+import { getBlogFooterInfo, getBlogHeaderInfo } from '@/apis/blogHome';
 import BlogFooter from '@/components/common/BlogFooter';
 import BlogHeader from '@/components/common/BlogHeader';
 
@@ -9,19 +9,25 @@ import NotFound from '../not-found';
 // export const runtime = 'edge';
 const BlogHomeLayout = async ({ children, params }: { children: React.ReactElement; params: { team: string } }) => {
   const blogHeaderInfoRes = await getBlogHeaderInfo(params.team);
+  const blogFooterInfoRes = await getBlogFooterInfo(params.team);
 
-  if (!blogHeaderInfoRes || blogHeaderInfoRes.code === 404) return <NotFound />;
-  if (!blogHeaderInfoRes.data) return <></>;
+  if (!blogHeaderInfoRes || blogHeaderInfoRes.code === 404 || !blogFooterInfoRes || blogFooterInfoRes.code === 404)
+    return <NotFound />;
+  if (!blogHeaderInfoRes.data || !blogFooterInfoRes.data) return <></>;
 
   const {
     data: { logo, blogName, navList },
   } = blogHeaderInfoRes;
 
+  const {
+    data: { ownerName, ownerInfo },
+  } = blogFooterInfoRes;
+
   return (
     <>
       <BlogHeader logo={logo} blogName={blogName} navList={navList} />
       <main style={{ overflowX: 'hidden' }}>{children}</main>
-      <BlogFooter />
+      <BlogFooter companyName={ownerName} companyDetail={ownerInfo} />
     </>
   );
 };

--- a/components/common/BlogFooter.tsx
+++ b/components/common/BlogFooter.tsx
@@ -16,28 +16,28 @@ const BlogFooter = (props: BlogFooterProps) => {
 
   const MOBILE = useCheckMobile();
 
+  const footerMain = () => {
+    return (
+      <>
+        <CompanyName>{companyName}</CompanyName>
+        <CompanyDetail>{companyDetail}</CompanyDetail>
+        <MadeWithPalms>
+          made with <LandingPageLink href={`https://www.palms.blog/`}>palms.blog</LandingPageLink>
+        </MadeWithPalms>
+      </>
+    );
+  };
+
   if (MOBILE)
     return (
       <FooterContainer>
-        <MobileFooterWrap>
-          <CompanyName>{companyName}</CompanyName>
-          <CompanyDetail>{companyDetail}</CompanyDetail>
-          <MadeWithPalms>
-            made with <LandingPageLink href={`https://www.palms.blog/`}>palms.blog</LandingPageLink>
-          </MadeWithPalms>
-        </MobileFooterWrap>
+        <MobileFooterWrap>{footerMain()}</MobileFooterWrap>
       </FooterContainer>
     );
   else
     return (
       <FooterContainer>
-        <FooterWrapper>
-          <CompanyName>{companyName}</CompanyName>
-          <CompanyDetail>{companyDetail}</CompanyDetail>
-          <MadeWithPalms>
-            made with <LandingPageLink href={`https://www.palms.blog/`}>palms.blog</LandingPageLink>
-          </MadeWithPalms>
-        </FooterWrapper>
+        <FooterWrapper>{footerMain()}</FooterWrapper>
       </FooterContainer>
     );
 };

--- a/components/common/BlogFooter.tsx
+++ b/components/common/BlogFooter.tsx
@@ -4,40 +4,97 @@ import React from 'react';
 import Link from 'next/link';
 import styled from 'styled-components';
 
-// footerContact는 추후 기획측과의 상의 후 수정/반영할 계획입니다. 일단은 빼기로해서 주석처리 해두겠습니다!
-// import FooterContact from './ui/FooterContact';
+import useCheckMobile from '@/hooks/useCheckMobile';
 
-const BlogFooter = () => {
-  return (
-    <FooterContainer>
-      {/* footerContact는 추후 기획측과의 상의 후 수정/반영할 계획입니다. 일단은 빼기로해서 주석처리 해두겠습니다! */}
-      {/* <FooterContact /> */}
-      <FeedbackLink href={'https://tally.so/r/w4rjGk'}>블로그 피드백 남기기</FeedbackLink>
-      <FooterName>Palmspring © 2023</FooterName>
-    </FooterContainer>
-  );
+interface BlogFooterProps {
+  companyName: string;
+  companyDetail: string;
+}
+
+const BlogFooter = (props: BlogFooterProps) => {
+  const { companyName, companyDetail } = props;
+
+  const MOBILE = useCheckMobile();
+
+  if (MOBILE)
+    return (
+      <FooterContainer>
+        <MobileFooterWrap>
+          <CompanyName>{companyName}</CompanyName>
+          <CompanyDetail>{companyDetail}</CompanyDetail>
+          <MadeWithPalms>
+            made with <LandingPageLink href={`https://www.palms.blog/`}>palms.blog</LandingPageLink>
+          </MadeWithPalms>
+        </MobileFooterWrap>
+      </FooterContainer>
+    );
+  else
+    return (
+      <FooterContainer>
+        <FooterWrapper>
+          <CompanyName>{companyName}</CompanyName>
+          <CompanyDetail>{companyDetail}</CompanyDetail>
+          <MadeWithPalms>
+            made with <LandingPageLink href={`https://www.palms.blog/`}>palms.blog</LandingPageLink>
+          </MadeWithPalms>
+        </FooterWrapper>
+      </FooterContainer>
+    );
 };
 
 export default BlogFooter;
 
-const FeedbackLink = styled(Link)`
-  ${({ theme }) => theme.fonts.Body3_Semibold};
-  color: ${({ theme }) => theme.colors.grey_700};
+const MadeWithPalms = styled.p`
+  cursor: default;
+  line-height: normal;
+  letter-spacing: -0.005rem;
+  color: #8c8c8c;
+  font-family: 'Pretendard';
+  font-size: 1.2rem;
+  font-weight: 400;
+  font-style: normal;
+`;
 
-  &:hover {
-    transition: 0.3s;
-    color: ${({ theme }) => theme.colors.green_hover};
-    font-weight: bolder;
-  }
+const FooterWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 72rem;
+`;
+
+const MobileFooterWrap = styled(FooterWrapper)`
+  margin-left: 2rem;
+`;
+
+const CompanyName = styled.p`
+  line-height: normal;
+  letter-spacing: -0.005em;
+  color: ${({ theme }) => theme.colors.grey_1000};
+  font-family: 'Pretendard';
+  font-size: 1.5rem;
+  font-weight: 600;
+  font-style: normal;
+`;
+
+const CompanyDetail = styled.p`
+  margin: 1.2rem 0 2.8rem;
+
+  line-height: 1.95rem;
+  letter-spacing: -0.005rem;
+  white-space: pre-line;
+
+  color: #8c8c8c;
+  font-family: 'Pretendard';
+  font-size: 1.3rem;
+  font-weight: 400;
+  font-style: normal;
 `;
 
 const FooterContainer = styled.div`
   ${({ theme }) => theme.fonts.Body3_Regular};
 
   display: flex;
-  flex-direction: column;
-  gap: 2rem;
-  align-items: center;
+  justify-content: center;
 
   border-top: 1px solid ${({ theme }) => theme.colors.grey_300};
 
@@ -45,7 +102,13 @@ const FooterContainer = styled.div`
   width: 100%;
 `;
 
-const FooterName = styled.div`
-  ${({ theme }) => theme.fonts.Body3_Semibold};
-  color: ${({ theme }) => theme.colors.grey_700};
+const LandingPageLink = styled(Link)`
+  text-decoration: underline;
+  line-height: normal;
+  letter-spacing: -0.005rem;
+  color: #8c8c8c;
+  font-family: 'Pretendard';
+  font-size: 1.2rem;
+  font-weight: 400;
+  font-style: normal;
 `;

--- a/components/common/ContentInfo.tsx
+++ b/components/common/ContentInfo.tsx
@@ -46,7 +46,7 @@ const ContentInfo = (props: ContentInfoProps) => {
   if (MOBILE)
     return (
       <ContentInfoContainer className="mobile">
-        {ifContent === 'content' ? (
+        {ifContent ? (
           <ContentDetailBox>
             <TitleBox className="mobile">{title}</TitleBox>
             {description && <DescriptionBox className="mobile">{description}</DescriptionBox>}
@@ -82,7 +82,7 @@ const ContentInfo = (props: ContentInfoProps) => {
   else
     return (
       <ContentInfoContainer className={ifContent === 'content' ? 'noHover' : 'hover'}>
-        {ifContent === 'content' ? (
+        {ifContent ? (
           <ContentDetailBox>
             <TitleBox>{title}</TitleBox>
             {description && <DescriptionBox>{description}</DescriptionBox>}
@@ -171,7 +171,7 @@ const WriterNameBox = styled.div`
   ${({ theme }) => theme.fonts.Body2_Regular};
 `;
 
-const TitleBox = styled.article`
+const TitleBox = styled.h1`
   ${({ theme }) => theme.fonts.Title};
 
   display: flex;

--- a/components/common/PageContentInfo.tsx
+++ b/components/common/PageContentInfo.tsx
@@ -30,7 +30,7 @@ const PageContentInfo = (props: PageContentInfoProps) => {
   if (MOBILE)
     return (
       <ContentInfoContainer className="mobile">
-        {ifContent === 'content' ? (
+        {ifContent ? (
           <ContentDetailBox>
             <TitleBox className="mobile">{title}</TitleBox>
             {description && <DescriptionBox className="mobile">{description}</DescriptionBox>}
@@ -48,7 +48,7 @@ const PageContentInfo = (props: PageContentInfoProps) => {
   else
     return (
       <ContentInfoContainer className={ifContent === 'content' ? 'noHover' : 'hover'}>
-        {ifContent === 'content' ? (
+        {ifContent ? (
           <ContentDetailBox>
             <TitleBox>{title}</TitleBox>
             {description && <DescriptionBox>{description}</DescriptionBox>}
@@ -94,7 +94,7 @@ const ContentInfoContainer = styled.section`
   }
 `;
 
-const TitleBox = styled.article`
+const TitleBox = styled.h1`
   ${({ theme }) => theme.fonts.Title};
 
   display: flex;

--- a/hooks/useGetIfContentPage.ts
+++ b/hooks/useGetIfContentPage.ts
@@ -1,5 +1,5 @@
 import { usePathname } from 'next/navigation';
 
-const useGetIfContentPage = (): string => usePathname().split('/').slice(-4)[0] as string;
+const useGetIfContentPage = (): string => usePathname().split('/').slice(-1)[0] as string;
 
 export default useGetIfContentPage;

--- a/types/blogHeader.ts
+++ b/types/blogHeader.ts
@@ -3,6 +3,12 @@ export interface HeaderProps extends NavListOnly {
   blogName: string;
 }
 
+export interface FooterProps {
+  ownerName: string;
+  logo: string;
+  footerInfo: string;
+}
+
 export interface subscribeData {
   email: string;
   blogUrl: string;

--- a/types/blogHeader.ts
+++ b/types/blogHeader.ts
@@ -4,9 +4,9 @@ export interface HeaderProps extends NavListOnly {
 }
 
 export interface FooterProps {
-  ownerName: string;
-  logo: string;
-  footerInfo: string;
+  ownerName: string | null;
+  logo: string | null;
+  footerInfo: string | null;
 }
 
 export interface subscribeData {


### PR DESCRIPTION
## 🔥 Related Issues
- close #5 

## 💙 작업 내용
- [x] footer get api 연결 
- [x] footer 커스텀 반영
- [x] 아티클과 페이지 상세에서 글 제목에 링크가 걸려있는 문제 수정

## ✅ PR Point
>리뷰어가 중점적으로 봐야 하는 부분, 구현 방식 및 코드에 대한 부가 설명
- 슬랙에 디디한테 물어본 것처럼 **made with palms.blog**의 **palms.blog**에 랜딩페이지 링크 걸어뒀습니다
- 회사 추가 설명에 줄바꿈한 텍스트는 css에 `white-space: pre-line;`를 추가해 완성했습니다
- 필요없는 주석은 삭제했습니당~
- 아티클과 페이지 상세에서 글 제목에 링크가 걸려있던 문제는 아티클과 페이지의 url을 수정하면서 발생한 문제였어서 기존에 쓰던 hook을 수정해 해결했습니당~ 추가로 제목 부분 태그도 h1태그로 수정해뒀습니당



## 😡 해결하지 못한 점 (Optional)
- 없숨다-!

## 📚 Reference (Optional)
- https://velog.io/@stakbucks/%EB%A6%AC%EC%95%A1%ED%8A%B8-%EB%AC%B8%EC%9E%90%EC%97%B4-%EC%B6%9C%EB%A0%A5-n-%EC%A4%84%EB%B0%94%EA%BF%88-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0
