### PR TITLE
feat/#23: 블로그 각종 스타일 수정 및 개선

### DIFF
--- a/components/blog/BlogImg.tsx
+++ b/components/blog/BlogImg.tsx
@@ -59,7 +59,7 @@ const BlogInfo = styled.div`
 
 const BlogImgContainer = styled.div<{ $noArticle?: boolean }>`
   position: relative;
-  margin-top: 6rem;
+  margin-top: 7.2rem;
   /* padding-bottom: ${({ $noArticle }) => ($noArticle ? '22.3rem' : 0)}; */
   width: 100%;
 `;

--- a/components/blog/PageBtn.tsx
+++ b/components/blog/PageBtn.tsx
@@ -15,12 +15,13 @@ const PageBtnContainer = styled.button`
   align-items: center;
   justify-content: center;
   border-radius: 0.8rem;
-  padding: 1rem;
+  padding: 0.6rem 1.2rem;
   height: 3.6rem;
   text-align: center;
   text-overflow: ellipsis;
   white-space: nowrap;
   color: ${({ theme }) => theme.colors.grey_900};
+  font-size: 1.4rem;
   font-weight: 500;
 
   &:hover {

--- a/components/blog/ui/ArticleListWithThumbnail.tsx
+++ b/components/blog/ui/ArticleListWithThumbnail.tsx
@@ -96,7 +96,7 @@ const ContentInfoContainer = styled.div`
   flex-direction: column;
   align-items: center;
 
-  margin-top: 12rem;
+  margin-top: 13.2rem;
   width: 100%;
 `;
 
@@ -115,6 +115,6 @@ const CategoryBtnWrapper = styled.div<{ $thumbnail: string | null }>`
   width: 100vw;
 
   &.mobile {
-    margin-top: ${({ $thumbnail }) => ($thumbnail ? 0 : '6rem')};
+    margin-top: ${({ $thumbnail }) => ($thumbnail ? 0 : '7.2rem')};
   }
 `;

--- a/components/common/Article.tsx
+++ b/components/common/Article.tsx
@@ -7,7 +7,6 @@ import Link from 'next/link';
 import styled from 'styled-components';
 
 import useGetCategory from '@/hooks/useGetCategory';
-
 import { ArticleData } from '@/types/article';
 
 interface ArticleProps {

--- a/components/common/BlogHeader.tsx
+++ b/components/common/BlogHeader.tsx
@@ -14,12 +14,12 @@ import SideBar from './SideBar';
 const BlogHeader = (props: HeaderProps) => {
   const { logo, blogName, navList, isDeviceMobile } = props;
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [ifScrollPositionZero, setIfScrollPositionZero] = useState(true);
+  const [ifScrollPositionZero, setIfScrollPositionZero] = useState<boolean>(true);
 
   useEffect(() => {
     const handleScroll = () => {
       const position = window.scrollY;
-      setIfScrollPositionZero(position == 0);
+      setIfScrollPositionZero(position === 0);
     };
 
     window.addEventListener('scroll', handleScroll);
@@ -74,23 +74,17 @@ const BlogHeaderContainer = styled.div<{ $ifscrollpositionzero: boolean }>`
   align-items: center;
   justify-content: space-between;
   transition: height 300ms cubic-bezier(0.31, 0.27, 0.15, 0.99) 0s;
-  /* backdrop-filter: blur(18px); */
   z-index: 10;
   border-bottom: 1px solid ${({ theme }) => theme.colors.grey_300};
 
-  /* background-color: rgba(255, 255, 255, 0.75); */
   background: ${({ theme }) => theme.colors.grey_0};
-  /* padding: 1.2rem max(calc((100vw - 100rem) / 2), 2.4rem); */
   padding: 0 max(calc((100vw - 100rem) / 2), 2.4rem);
   width: 100vw;
   min-width: 72rem;
   height: 6rem;
-  ${({ $ifscrollpositionzero }) => $ifscrollpositionzero == true && `height:7.2rem;border-color:transparent;`}
+  ${({ $ifscrollpositionzero }) => $ifscrollpositionzero && `height:7.2rem;border-color:transparent;`}
 
   &.mobile {
-    /* stylelint-disable-next-line property-no-vendor-prefix */
-    /* -webkit-backdrop-filter: blur(18px); */
-    /* backdrop-filter: blur(18px); */
     padding: 0 1.6rem 0 2.4rem;
     min-width: 0;
   }

--- a/components/common/BlogHeader.tsx
+++ b/components/common/BlogHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import useCheckMobile from '@/hooks/useCheckMobile';
@@ -14,6 +14,20 @@ import SideBar from './SideBar';
 const BlogHeader = (props: HeaderProps) => {
   const { logo, blogName, navList, isDeviceMobile } = props;
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [ifScrollPositionZero, setIfScrollPositionZero] = useState(true);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const position = window.scrollY;
+      setIfScrollPositionZero(position == 0);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
 
   const isMobile = useCheckMobile(isDeviceMobile);
 
@@ -21,7 +35,7 @@ const BlogHeader = (props: HeaderProps) => {
 
   if (isMobile)
     return (
-      <BlogHeaderContainer className="mobile">
+      <BlogHeaderContainer className="mobile" $ifscrollpositionzero={ifScrollPositionZero}>
         <HeaderLogo logo={logo} blogName={blogName} />
         <BlurBackground className={isMenuOpen ? 'blur' : ''} onClick={sidebarToggle} />
         <SideBar isMenuOpen={isMenuOpen} setIsMenuOpen={setIsMenuOpen} navList={navList} />
@@ -30,7 +44,7 @@ const BlogHeader = (props: HeaderProps) => {
     );
   else
     return (
-      <BlogHeaderContainer>
+      <BlogHeaderContainer $ifscrollpositionzero={ifScrollPositionZero}>
         <HeaderLogo logo={logo} blogName={blogName} />
         <BlogNav blogName={blogName} navList={navList} />
       </BlogHeaderContainer>
@@ -40,11 +54,11 @@ const BlogHeader = (props: HeaderProps) => {
 export default BlogHeader;
 
 const BlurBackground = styled.div`
+  transition: 0.2s ease-in-out;
   &.blur {
     position: fixed;
     top: 0;
     right: 0;
-    transition: 0.1ms ease-in-out;
     opacity: 1;
     z-index: 2;
     background-color: rgba(64, 71, 79, 0.5);
@@ -53,27 +67,31 @@ const BlurBackground = styled.div`
   }
 `;
 
-const BlogHeaderContainer = styled.div`
+const BlogHeaderContainer = styled.div<{ $ifscrollpositionzero: boolean }>`
   display: flex;
   position: fixed;
   top: 0;
   align-items: center;
   justify-content: space-between;
-  backdrop-filter: blur(18px);
+  transition: height 300ms cubic-bezier(0.31, 0.27, 0.15, 0.99) 0s;
+  /* backdrop-filter: blur(18px); */
   z-index: 10;
-
   border-bottom: 1px solid ${({ theme }) => theme.colors.grey_300};
-  background-color: rgba(255, 255, 255, 0.75);
-  padding: 1.2rem max(calc((100vw - 100rem) / 2), 2.4rem);
+
+  /* background-color: rgba(255, 255, 255, 0.75); */
+  background: ${({ theme }) => theme.colors.grey_0};
+  /* padding: 1.2rem max(calc((100vw - 100rem) / 2), 2.4rem); */
+  padding: 0 max(calc((100vw - 100rem) / 2), 2.4rem);
   width: 100vw;
   min-width: 72rem;
   height: 6rem;
+  ${({ $ifscrollpositionzero }) => $ifscrollpositionzero == true && `height:7.2rem;border-color:transparent;`}
 
   &.mobile {
     /* stylelint-disable-next-line property-no-vendor-prefix */
-    -webkit-backdrop-filter: blur(18px);
-    justify-content: space-between;
-    padding: 1.2rem 1.6rem 1.2rem 2.4rem;
+    /* -webkit-backdrop-filter: blur(18px); */
+    /* backdrop-filter: blur(18px); */
+    padding: 0 1.6rem 0 2.4rem;
     min-width: 0;
   }
 `;

--- a/components/common/BlogNav.tsx
+++ b/components/common/BlogNav.tsx
@@ -37,7 +37,7 @@ export default BlogNav;
 
 const BlogNavContainer = styled.div`
   display: flex;
-  gap: 1.6rem;
+  gap: 1rem;
   align-items: center;
   justify-content: space-between;
 

--- a/components/common/ContentInfo.tsx
+++ b/components/common/ContentInfo.tsx
@@ -211,7 +211,7 @@ const WriterInfo = styled(Link)`
   justify-content: flex-start;
 
   &.mobile {
-    gap: 0.8rem;
+    gap: 1.2rem;
   }
 `;
 

--- a/components/common/PageContentInfo.tsx
+++ b/components/common/PageContentInfo.tsx
@@ -104,7 +104,6 @@ const TitleBox = styled.h1`
   color: ${({ theme }) => theme.colors.grey_950};
 
   &.mobile {
-    margin-top: 6rem;
     ${({ theme }) => theme.mobileFonts.Title1};
   }
 `;

--- a/components/common/SideBar.tsx
+++ b/components/common/SideBar.tsx
@@ -66,16 +66,15 @@ const SideBarWrapper = styled.div`
   transition: 0.3s ease-in-out;
   z-index: 5;
   background-color: ${({ theme }) => theme.colors.grey_0};
-  width: 26.6rem;
+  width: 80vw;
   height: 100vh;
 
   &.closed {
-    right: -26.6rem;
+    right: -80vw;
   }
 
   &.open {
     right: 0;
-    transition: 0.3s ease-in-out;
   }
 `;
 const SideBarHeader = styled.div`

--- a/components/common/SideBarNav.tsx
+++ b/components/common/SideBarNav.tsx
@@ -35,6 +35,7 @@ const NavLink = styled(Link)`
   text-overflow: ellipsis;
   word-break: break-all;
   color: ${({ theme }) => theme.colors.grey_900};
+  font-size: 1.5rem;
 
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -48,7 +49,7 @@ const BlogNavContainer = styled.div`
   align-items: center;
   justify-content: space-between;
 
-  width: 26.6rem;
+  width: 100%;
 `;
 
 const NavBtn = styled.button`

--- a/components/content/ui/ArticleTemplate.tsx
+++ b/components/content/ui/ArticleTemplate.tsx
@@ -6,7 +6,6 @@ import { DiscussionEmbed } from 'disqus-react';
 import Image from 'next/image';
 import { useParams } from 'next/navigation';
 import styled from 'styled-components';
-import * as gtag from '@/utils/getGtagEvents';
 
 import ContentInfo from '@/components/common/ContentInfo';
 import CopyLinkButton from '@/components/common/CopyLinkButton';
@@ -16,6 +15,7 @@ import Recommend from '@/components/content/ui/Recommend';
 import useCheckMobile from '@/hooks/useCheckMobile';
 import { ArticleData, SingleArticleData } from '@/types/article';
 import { ContentProps } from '@/types/content';
+import * as gtag from '@/utils/getGtagEvents';
 import { createToast } from '@/utils/lib/toast';
 
 import MobileContent from '../MobileContent';
@@ -93,25 +93,17 @@ const ArticleTemplate = (props: ArticleTemplateProps) => {
             <Content content={content} />
             <CopyLinkButton viewType="" onClickAction={copyCurrentUrl} />
             <Bar />
-            {team === 'forweber' && (
-              <DiscussionEmbed
-                shortname={process.env.NEXT_PUBLIC_SHORT_NAME}
-                config={{
-                  url: `https://${team}.${process.env.DOMAIN_NAME}/${contentUrl}`,
-                  identifier: String(contentUrl),
-                  title: title,
-                }}
-              />
-            )}
-            {team === 'init' && (
-              <DiscussionEmbed
-                shortname={process.env.NEXT_PUBLIC_SHORT_NAME}
-                config={{
-                  url: `https://${team}.${process.env.DOMAIN_NAME}/${contentUrl}`,
-                  identifier: String(contentUrl),
-                  title: title,
-                }}
-              />
+            {(team === 'forweber' || team === 'init') && (
+              <div style={{ marginBottom: '4rem' }}>
+                <DiscussionEmbed
+                  shortname={process.env.NEXT_PUBLIC_SHORT_NAME}
+                  config={{
+                    url: `https://${team}.${process.env.DOMAIN_NAME}/${contentUrl}`,
+                    identifier: String(contentUrl),
+                    title: title,
+                  }}
+                />
+              </div>
             )}
             <Recommend data={recommendedArticles} isMobile={isMobile} />
           </ContentPageContainer>
@@ -145,7 +137,7 @@ const CommentContainer = styled.div`
 
 const Blank = styled.div`
   width: 100vw;
-  height: 6rem;
+  height: 7.2rem;
 `;
 const ArticleThumbnail = styled(Image)`
   border-radius: 1.6rem;
@@ -157,7 +149,7 @@ const ArticleThumbnail = styled(Image)`
   object-fit: cover;
 
   &.mobile {
-    margin-top: 6rem;
+    margin-top: 7.2rem;
     border-radius: 0;
     width: 100%;
     height: calc(100vw * 9 / 16);

--- a/components/content/ui/ArticleTemplate.tsx
+++ b/components/content/ui/ArticleTemplate.tsx
@@ -94,7 +94,7 @@ const ArticleTemplate = (props: ArticleTemplateProps) => {
             <CopyLinkButton viewType="" onClickAction={copyCurrentUrl} />
             <Bar />
             {(team === 'forweber' || team === 'init') && (
-              <div style={{ marginBottom: '4rem' }}>
+              <DiscussionEmbedContainer>
                 <DiscussionEmbed
                   shortname={process.env.NEXT_PUBLIC_SHORT_NAME}
                   config={{
@@ -103,7 +103,7 @@ const ArticleTemplate = (props: ArticleTemplateProps) => {
                     title: title,
                   }}
                 />
-              </div>
+              </DiscussionEmbedContainer>
             )}
             <Recommend data={recommendedArticles} isMobile={isMobile} />
           </ContentPageContainer>
@@ -166,4 +166,7 @@ const ContentPageContainer = styled.section`
     margin: 0;
     width: 100vw;
   }
+`;
+const DiscussionEmbedContainer = styled.div`
+  margin-bottom: 4rem;
 `;

--- a/components/content/ui/PageTemplate.tsx
+++ b/components/content/ui/PageTemplate.tsx
@@ -33,7 +33,7 @@ const PageTemplate = (props: ContentTemplateProps) => {
 
   return (
     <ContentPageContainer className={isMobile ? 'mobile' : ''}>
-      {thumbnail && (
+      {thumbnail ? (
         <PageThumbnail
           className={isMobile ? 'mobile' : ''}
           src={thumbnail}
@@ -41,6 +41,8 @@ const PageTemplate = (props: ContentTemplateProps) => {
           width={720}
           height={405}
         />
+      ) : (
+        isMobile && <Blank />
       )}
       <PageContentInfo contentInfoData={{ title }} isMobile={isMobile} />
       {isMobile ? <MobileContent content={content} /> : <Content content={content} />}
@@ -75,7 +77,12 @@ const ContentPageContainer = styled.section`
   margin: 12rem 36rem;
 
   &.mobile {
-    margin: 0;
+    margin: 0 0 6rem 0;
     width: 100%;
   }
+`;
+
+const Blank = styled.div`
+  width: 100vw;
+  height: 7.2rem;
 `;

--- a/styles/MobileTextEditorStyle.ts
+++ b/styles/MobileTextEditorStyle.ts
@@ -4,83 +4,72 @@ import { styled } from 'styled-components';
 
 export const MobileTextEditorStyle = styled.div`
   .ProseMirror {
+    width: 100vw;
     color: #333d4b;
+
+    /* 기본 */
     * {
       word-wrap: break-word;
     }
 
+    /* 문단 */
     p {
       ${({ theme }) => theme.mobileFonts.Body1_Regular};
-      margin: 2.4rem 0 0.8rem 0;
-      width: calc(100vw - 4rem);
+      margin: 0 0 1.2rem 0;
+      width: 100%;
     }
 
-    h1 {
-      ${({ theme }) => theme.mobileFonts.Markdown_H1};
-      margin: 4rem 0 0.4rem;
-      width: calc(100vw - 4rem);
-      color: ${({ theme }) => theme.colors.grey_950};
-    }
-
-    h2 {
-      ${({ theme }) => theme.mobileFonts.Markdown_H2};
-      margin: 3.2 0 0.4rem;
-      width: calc(100vw - 4rem);
-      color: ${({ theme }) => theme.colors.grey_950};
-    }
-
-    h3 {
-      ${({ theme }) => theme.mobileFonts.Markdown_H3};
-      margin: 2.4rem 0 0.4rem;
-      width: calc(100vw - 4rem);
-      color: ${({ theme }) => theme.colors.grey_950};
-    }
-
-    ul {
-      display: flex;
-      flex-direction: column;
-      gap: 0.6rem;
-      margin: 2.4rem 0 0.4rem 4rem;
-      width: calc(100vw - 4rem);
-      list-style-type: disc;
-    }
-
+    /* 리스트 */
+    ul,
     ol {
       display: flex;
       flex-direction: column;
-      gap: 0.6rem;
-      margin: 2.4rem 0 0.4rem 4rem;
-      width: calc(100vw - 8rem);
+      gap: 0.8rem;
+      margin: 0 0 1.2rem 0;
+      padding: 0 1rem 0 2.4rem;
+      width: 100%;
+    }
+    ul {
+      list-style-type: disc;
+    }
+    ol {
       list-style-type: decimal;
     }
 
+    /* 코드 */
     code {
+      border: 1px solid ${({ theme }) => theme.colors.grey_400};
       border-radius: 0.25em;
       background-color: ${({ theme }) => theme.colors.grey_200};
       padding: 0.3rem 0.6rem;
-      box-decoration-break: clone;
+      width: 100%;
       overflow-x: scroll;
+      font-family: 'Fira Mono' !important;
+      font-size: 1.53rem;
+      font-weight: 400;
+      font-style: normal;
+      box-decoration-break: clone;
     }
 
     pre {
-      margin: 2.4rem 0 0.4rem;
+      margin: 1.2rem 0 2rem 0;
       border-radius: 0.5rem;
       background: ${({ theme }) => theme.colors.grey_100};
       padding: 1.6rem 2rem;
       width: 100%;
-      /* width: calc(100vw - 4rem); */
       max-width: calc(100vw - 4rem);
       /* 이거 코드블럭만 피라모노! */
       /* white-space: pre-wrap; */
       overflow-x: scroll;
       word-break: break-all;
       color: #383a41;
-      font-family: 'Fira Mono', monospace;
+      font-family: 'Fira Mono', monospace !important;
 
       code {
+        border: 0;
         background: none;
         padding: 0;
-        width: calc(100vw - 4rem);
+        /* width: calc(100vw - 4rem); 모바일 pre 태그 안에서는 어차피 좌우스크롤이기 때문에 width가 의미가 없음 */
         overflow-x: scroll;
         color: inherit;
         font-size: 1.4rem;
@@ -151,98 +140,121 @@ export const MobileTextEditorStyle = styled.div`
       }
     }
 
+    /* 인용 */
     blockquote {
       display: flex;
       flex-direction: column;
-      gap: 0.6rem;
-      margin: 2.4rem 0 0.8rem 0;
-      border-left: 2px solid ${({ theme }) => theme.colors.grey_900};
-      padding-left: 1.8rem;
-      width: calc(100vw - 4rem);
-      height: 100%;
+      gap: 0.8rem;
+      margin: 1.2rem 0 2rem 0;
+      border-left: 3px solid ${({ theme }) => theme.colors.grey_900};
+      background: ${({ theme }) => theme.colors.grey_100};
+      padding: 1.2rem 1.2rem 1.2rem 2rem;
+      width: 100%;
 
-      p {
+      & > * {
         margin: 0;
-        width: calc(100vw - 6rem);
       }
-
-      pre {
-        width: calc(100vw - 6rem);
-      }
-
       /* ul > li > p {
         width: calc(100vw - 10rem);
       } */
     }
 
-    li {
-      width: calc(100vw - 10rem);
-
-      & > p {
-        margin: 0;
-        width: 100%;
-      }
-
-      & > blockquote {
-        width: 100%;
-      }
-
-      & > blockquote > p {
-        width: 100%;
-      }
-
-      & > ul > li {
-        width: calc(100vw - 14rem);
-      }
-
-      & > ul > li > ul > li {
-        width: calc(100vw - 16rem);
-      }
-    }
-
+    /* 언더라인 */
     u {
       text-decoration: underline;
     }
 
+    /* 구분선 */
     hr {
+      margin: 1.2rem 0;
       border: 1px solid ${({ theme }) => theme.colors.grey_300};
-      width: calc(100vw - 4rem);
+      width: 100%;
     }
 
+    /* 볼드 */
     strong {
       ${({ theme }) => theme.mobileFonts.Body1_Semibold};
-      width: calc(100vw - 4rem);
     }
 
+    /* 취소선 */
     s {
-      width: calc(100vw - 4rem);
       text-decoration: line-through;
     }
 
+    /* 이탤릭 */
     em {
-      width: calc(100vw - 4rem);
       font-style: italic;
     }
 
+    /* 이미지 */
     img {
-      margin-top: 2.4rem 0 0.8rem 0;
-      width: calc(100vw - 4rem);
+      margin: 2rem 0;
+      border-radius: 12px;
+      width: 100%;
       height: auto;
-
-      &.ProseMirror-selectednode {
-        outline: 3px solid #68cef8;
-      }
     }
 
+    /* 링크 */
     a {
       border-bottom: 0.8px solid ${({ theme }) => theme.colors.grey_700};
-      width: calc(100vw - 4rem);
       text-decoration: none;
       color: ${({ theme }) => theme.colors.grey_700};
       &:hover {
         border-color: #0056b3;
         color: #0056b3;
       }
+    }
+
+    /* 헤딩 */
+    h1 {
+      ${({ theme }) => theme.mobileFonts.Markdown_H1};
+      margin: 4rem 0 0.8rem;
+      width: 100%;
+      color: ${({ theme }) => theme.colors.grey_950};
+      * {
+        ${({ theme }) => theme.mobileFonts.Markdown_H1};
+        color: ${({ theme }) => theme.colors.grey_950};
+      }
+    }
+
+    h2 {
+      ${({ theme }) => theme.mobileFonts.Markdown_H2};
+      margin: 3.2rem 0 0.8rem;
+      width: 100%;
+      color: ${({ theme }) => theme.colors.grey_950};
+      * {
+        ${({ theme }) => theme.mobileFonts.Markdown_H2};
+        color: ${({ theme }) => theme.colors.grey_950};
+      }
+    }
+
+    h3 {
+      ${({ theme }) => theme.mobileFonts.Markdown_H3};
+      margin: 2.4rem 0 0.8rem;
+      width: 100%;
+      color: ${({ theme }) => theme.colors.grey_950};
+      * {
+        ${({ theme }) => theme.mobileFonts.Markdown_H3};
+        color: ${({ theme }) => theme.colors.grey_950};
+      }
+    }
+
+    /* 리스트 아이템 */
+    li {
+      width: 100%;
+      & > p:nth-of-type(1) {
+        margin: 0;
+      }
+      & > * {
+        margin: 0.8rem 0 0 0;
+      }
+      & > *:not(:first-child):last-child {
+        margin-bottom: 0.4rem;
+      }
+    }
+
+    .ProseMirror-separator {
+      display: none;
     }
   }
 `;

--- a/styles/TextEditorStyle.ts
+++ b/styles/TextEditorStyle.ts
@@ -4,90 +4,47 @@ import { styled } from 'styled-components';
 
 export const TextEditorStyle = styled.div`
   .ProseMirror {
-    margin: 4rem auto 0;
-    width: 72.2rem;
+    margin: 4.8rem auto 0;
+    width: 72rem;
     color: #333d4b;
+
+    /* 기본 */
     * {
       word-wrap: break-word;
     }
 
+    /* 문단 */
     p {
       ${({ theme }) => theme.fonts.Body1_Regular};
-      margin: 2.4rem 0 0.8rem 0;
-      width: 72rem;
+      /* margin: 2.4rem 0 0.8rem 0; */
+      margin: 0 0 1.2rem 0;
+      width: 100%;
     }
 
-    h1 {
-      ${({ theme }) => theme.editor.Edit_h1};
-      margin: 5.6rem 0 0.4rem 0;
-      width: 72rem;
-      color: ${({ theme }) => theme.colors.grey_950};
-    }
-
-    h2 {
-      ${({ theme }) => theme.editor.Edit_h2};
-      margin: 4rem 0 0.4rem 0;
-      width: 72rem;
-      color: ${({ theme }) => theme.colors.grey_950};
-    }
-
-    h3 {
-      ${({ theme }) => theme.editor.Edit_h3};
-      margin: 2.4rem 0 0.4rem;
-      width: 72rem;
-      color: ${({ theme }) => theme.colors.grey_950};
-    }
-
+    /* 리스트 */
+    ol,
     ul {
       display: flex;
       flex-direction: column;
-      gap: 0.6rem;
-      margin: 2.4rem 0 0.4rem 4rem;
-      width: 72rem;
+      gap: 0.8rem;
+      margin: 0 0 1.2rem 0;
+      padding: 0 1rem 0 3.2rem;
+      width: 100%;
+    }
+    ul {
       list-style-type: disc;
     }
-
     ol {
-      display: flex;
-      flex-direction: column;
-      gap: 0.6rem;
-      margin: 2.4rem 0 0.4rem 4rem;
-      width: 72rem;
       list-style-type: decimal;
     }
 
-    li {
-      & > p {
-        margin: 0;
-      }
-    }
-
-    u {
-      width: 72rem;
-      text-decoration: underline;
-    }
-
-    hr {
-      border: 1px solid ${({ theme }) => theme.colors.grey_300};
-      width: 100%;
-    }
-    strong {
-      ${({ theme }) => theme.fonts.Body1_Semibold};
-    }
-
-    s {
-      text-decoration: line-through;
-    }
-
-    em {
-      font-style: italic;
-    }
-
+    /* 코드 */
     code {
+      border: 1px solid ${({ theme }) => theme.colors.grey_400};
       border-radius: 0.25em;
       background-color: ${({ theme }) => theme.colors.grey_200};
       padding: 0.3rem 0.6rem;
-      width: 72rem;
+      width: 100%;
       line-height: 2.601rem;
       letter-spacing: -0.0072rem;
       font-family: 'Fira Mono' !important;
@@ -98,11 +55,11 @@ export const TextEditorStyle = styled.div`
     }
 
     pre {
-      margin: 2.016rem 0 0.8rem;
+      margin: 1.2rem 0 2rem 0;
       border-radius: 0.5rem;
       background: ${({ theme }) => theme.colors.grey_100};
       padding: 1.6rem 2rem;
-      width: 72rem;
+      width: 100%;
       line-height: 2.601rem;
       letter-spacing: -0.0072rem;
       white-space: pre-wrap;
@@ -111,13 +68,14 @@ export const TextEditorStyle = styled.div`
       font-family: 'Fira Mono' !important;
       font-size: 1.4rem;
       font-weight: 400;
+
       code {
+        border: 0;
         background: none;
         padding: 0;
         line-height: 2.601rem;
         letter-spacing: -0.0072rem;
         color: inherit;
-        font-family: 'Fira Mono' !important;
         font-size: 1.4rem;
         font-weight: 400;
       }
@@ -246,31 +204,59 @@ export const TextEditorStyle = styled.div`
       }
     }
 
+    /* 인용 */
     blockquote {
       display: flex;
       flex-direction: column;
-      gap: 0.6rem;
-      margin: 2.4rem 0 0.8rem 0;
-      border-left: 2px solid ${({ theme }) => theme.colors.grey_900};
-      padding-left: 1.8rem;
+      gap: 0.8rem;
+      margin: 1.2rem 0 2rem 0;
+      border-left: 3px solid ${({ theme }) => theme.colors.grey_900};
+      background: ${({ theme }) => theme.colors.grey_100};
+      padding: 1.2rem 1.2rem 1.2rem 2rem;
+      width: 100%;
 
-      p {
+      & > * {
         margin: 0;
       }
     }
 
+    /* 언더라인 */
+    u {
+      width: 100%;
+      text-decoration: underline;
+    }
+
+    /* 구분선 */
+    hr {
+      margin: 1.2rem 0;
+      border: 1px solid ${({ theme }) => theme.colors.grey_300};
+      width: 100%;
+    }
+
+    /* 볼드 */
+    strong {
+      ${({ theme }) => theme.fonts.Body1_Semibold};
+    }
+
+    /* 취소선 */
+    s {
+      text-decoration: line-through;
+    }
+
+    /* 이탤릭 */
+    em {
+      font-style: italic;
+    }
+
+    /* 이미지 */
     img {
-      margin-top: 2.4rem 0 0.8rem 0;
+      margin: 2rem 0;
       border-radius: 16px;
       width: 100%;
       height: auto;
-
-      &.ProseMirror-selectednode {
-        border: 2px solid ${({ theme }) => theme.colors.green};
-        border-radius: 16px;
-      }
     }
 
+    /* 링크 */
     a {
       border-bottom: 0.8px solid ${({ theme }) => theme.colors.grey_700};
       text-decoration: none;
@@ -280,11 +266,57 @@ export const TextEditorStyle = styled.div`
         color: #0056b3;
       }
     }
-  }
 
-  &.editor > .ProseMirror {
-    * {
-      font-family: sans-serif;
+    /* 헤딩 */
+    h1 {
+      ${({ theme }) => theme.editor.Edit_h1};
+      margin: 5.6rem 0 1.2rem 0;
+      width: 100%;
+      color: ${({ theme }) => theme.colors.grey_950};
+      * {
+        ${({ theme }) => theme.editor.Edit_h1};
+        color: ${({ theme }) => theme.colors.grey_950};
+      }
+    }
+
+    h2 {
+      ${({ theme }) => theme.editor.Edit_h2};
+      margin: 4rem 0 1.2rem 0;
+      width: 100%;
+      color: ${({ theme }) => theme.colors.grey_950};
+      * {
+        ${({ theme }) => theme.editor.Edit_h2};
+        color: ${({ theme }) => theme.colors.grey_950};
+      }
+    }
+
+    h3 {
+      ${({ theme }) => theme.editor.Edit_h3};
+      margin: 2.4rem 0 1.2rem;
+      width: 100%;
+      color: ${({ theme }) => theme.colors.grey_950};
+      * {
+        ${({ theme }) => theme.editor.Edit_h3};
+        color: ${({ theme }) => theme.colors.grey_950};
+      }
+    }
+
+    /* 리스트 아이템 */
+    li {
+      width: 100%;
+      & > p:nth-of-type(1) {
+        margin: 0;
+      }
+      & > * {
+        margin: 0.8rem 0 0 0;
+      }
+      & > *:not(:first-child):last-child {
+        margin-bottom: 0.4rem;
+      }
+    }
+
+    .ProseMirror-separator {
+      display: none;
     }
   }
 `;


### PR DESCRIPTION
각종 스타일을 수정 및 개선하였습니다.
특히, 지금 배포본에 올라가있는 수정된 아티클 스타일에 대한 서현이의 피드백(문단간 간격이 너무 넓은데, 너무 넓은 건 둘째치고 지금까지 작성된 글들이 이상해보이는 문제가 있다는 지적)을 새롭게 반영하였습니다.

제가 깃 사용에 미숙해서 커밋을 쪼개서 하지 못했습니다. 죄송합니다 😭 
그래서 작업 내용을 간략하게 소개해드리자면

- 헤더 스타일 개선 (모바일에서의 sidebarnav 포함)
- **아티클, 페이지 등 콘텐츠 스타일 개선**
- 페이지 콘텐츠의 레이아웃 자연스럽게 수정
- sidebar 스타일 개선
- 34기 웹파트 블로그에서만 보이는 disqus 블록 스타일 개선 (margin만 추가)
- 그 외에도 수정하지는 않았지만 그냥 열어봤다가 저장하는 바람에 자동으로 lint 적용된 수정내역

등이 있습니다.

콘텐츠 스타일 개선에 있어서는 충돌나는 부분이 없도록 최대한 꼼꼼하게 작성하되 특수한 요소만을 타겟하는 선택자는 최대한 지양하려고 노력했습니다(범용적으로 적용되는 스타일들만 작성했다는 의미). 부족한 부분이 있다면 피드백해주시면 감사하겠습니다!