### PR TITLE
feat/#29: 블로그 메인 등 스타일 개선 완료

### DIFF
--- a/app/[team]/layout.tsx
+++ b/app/[team]/layout.tsx
@@ -30,7 +30,7 @@ const BlogHomeLayout = async ({ children, params }: { children: React.ReactEleme
   return (
     <>
       <BlogHeader logo={logo} blogName={blogName} navList={navList} isDeviceMobile={isDeviceMobile} />
-      <main style={{ overflowX: 'hidden' }}>{children}</main>
+      <main>{children}</main>
       <BlogFooter companyName={ownerName} companyDetail={ownerInfo} isDeviceMobile={isDeviceMobile} />
     </>
   );

--- a/components/author/AuthorPageTemplate.tsx
+++ b/components/author/AuthorPageTemplate.tsx
@@ -56,7 +56,8 @@ const AuthorArticle = styled.div`
   ${({ theme }) => theme.fonts.Heading3_Semibold};
 
   margin-bottom: 2.8rem;
-  width: 72rem;
+  width: 100%;
+  max-width: 124rem;
 
   color: ${({ theme }) => theme.colors.grey_900};
 
@@ -73,7 +74,7 @@ const AuthorPageTemplateContainer = styled.section`
   flex-direction: column;
   align-items: center;
 
-  padding: 6rem 0 12rem;
+  padding: 6rem 2rem 12rem 2rem;
   width: 100vw;
 
   &.mobile {
@@ -85,11 +86,11 @@ const AuthorPageTemplateContainer = styled.section`
 const Line = styled.div`
   margin: 6rem 0;
   background-color: ${({ theme }) => theme.colors.grey_300};
-  width: 72rem;
+  width: 100%;
+  max-width: 124rem;
   height: 1px;
 
   &.mobile {
     margin: 4rem 0;
-    width: calc(100vw - 4.8rem);
   }
 `;

--- a/components/blog/BlogImg.tsx
+++ b/components/blog/BlogImg.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 interface BlogMainImgProps {
+  blogName: string;
   thumbnail: string | null;
   description: string | null;
   isMobile: boolean;
@@ -11,14 +12,17 @@ interface BlogMainImgProps {
 }
 
 const BlogImg = (props: BlogMainImgProps) => {
-  const { thumbnail, description, isMobile, noArticle } = props;
+  const { blogName, thumbnail, description, isMobile, noArticle } = props;
 
   return (
     //블로그 대문 이미지가 있는 경우에만 블로그 소개글이 같이 나타남
-    <BlogImgContainer $noArticle={noArticle}>
+    <BlogImgContainer $noArticle={noArticle} className={isMobile ? 'mobile' : ''}>
       {thumbnail && (
         <BlogImgWrapper className={isMobile ? 'mobile' : ''} thumbnail={thumbnail}>
-          <BlogInfo className={isMobile ? 'mobile' : ''}>{description}</BlogInfo>
+          <BlogInfoWrapper className={isMobile ? 'mobile' : ''}>
+            <BlogTitle className={isMobile ? 'mobile' : ''}>{description && blogName}</BlogTitle>
+            <BlogDescription className={isMobile ? 'mobile' : ''}>{description}</BlogDescription>
+          </BlogInfoWrapper>
         </BlogImgWrapper>
       )}
     </BlogImgContainer>
@@ -30,36 +34,62 @@ export default BlogImg;
 const BlogImgWrapper = styled.div<{ thumbnail?: string }>`
   display: flex;
   align-items: center;
-  justify-content: left;
+  justify-content: center;
+  border-radius: 16px;
   background-image: url(${(props) => props.thumbnail});
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
   padding: 0 3.2rem;
   width: 100%;
-  height: 50rem;
+  max-width: 124rem;
+  height: 38rem;
   &.mobile {
     padding: 0 2.4rem;
     height: calc(100vw * (9 / 16));
   }
 `;
 
-const BlogInfo = styled.div`
-  margin: auto;
+const BlogInfoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.8rem;
   width: 100%;
-  max-width: 100rem;
+  max-width: calc(100% - 7.6rem * 2);
+  &.mobile {
+    gap: 0.8rem;
+    max-width: unset;
+  }
+  @media (max-width: 1280px) {
+    max-width: calc(100% - 3.2rem * 2);
+  }
+`;
+const BlogTitle = styled.div`
+  width: 100%;
+  color: #000;
+  font-size: 4.8rem;
+  font-weight: 700;
+  &.mobile {
+    font-size: 2.4rem;
+  }
+`;
+const BlogDescription = styled.div`
+  width: 100%;
   line-height: 160%;
   white-space: pre-wrap;
-  color: #fff;
+  color: #000;
   font-size: 2.4rem;
   &.mobile {
-    font-size: 1.6rem;
+    font-size: 1.4rem;
   }
 `;
 
 const BlogImgContainer = styled.div<{ $noArticle?: boolean }>`
-  position: relative;
-  margin-top: 7.2rem;
+  display: flex;
+  justify-content: center;
+  margin: 12rem 0 0 0;
   /* padding-bottom: ${({ $noArticle }) => ($noArticle ? '22.3rem' : 0)}; */
-  width: 100%;
+  &.mobile {
+    margin: 8.2rem 0 0 0;
+  }
 `;

--- a/components/blog/PageBtn.tsx
+++ b/components/blog/PageBtn.tsx
@@ -11,6 +11,7 @@ export default PageBtn;
 
 const PageBtnContainer = styled.button`
   ${({ theme }) => theme.fonts.Body2_Regular};
+  ${({ theme }) => theme.transitions.Expand};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -24,9 +25,6 @@ const PageBtnContainer = styled.button`
   font-size: 1.4rem;
   font-weight: 500;
 
-  &:hover {
-    background-color: ${({ theme }) => theme.colors.navItem_hover};
-  }
   @media screen and (max-width: 768px) {
     display: none;
   }

--- a/components/blog/ui/ArticleContainer.tsx
+++ b/components/blog/ui/ArticleContainer.tsx
@@ -56,12 +56,12 @@ const ArticleContainer = (props: ArticleContainerProps) => {
   const categoryLiteralList = getLiteralCategoryList(categoryList);
 
   // props
-  const blogImgProps = { thumbnail, description };
+  const blogImgProps = { blogName, thumbnail, description };
   const articleProps = { articleList: articleListData, categoryLiteralList };
 
   // 아티클 X
   if (articleListData.length === 0) {
-    return <EmptyBlog isMobile={isMobile} blogName={blogName} {...blogImgProps} />;
+    return <EmptyBlog isMobile={isMobile} {...blogImgProps} />;
   }
 
   // 아티클 O

--- a/components/blog/ui/ArticleListWithThumbnail.tsx
+++ b/components/blog/ui/ArticleListWithThumbnail.tsx
@@ -24,13 +24,14 @@ interface ArticleListWithThumbnailProps {
   singleArticleDetail: Response<ContentProps> | null;
   isMobile: boolean;
   thumbnail: string | null;
+  blogName: string;
 }
 
 const ArticleListWithThumbnail = (props: ArticleListWithThumbnailProps) => {
-  const { articleList, categoryLiteralList, singleArticleDetail, isMobile, thumbnail, description } = props;
+  const { articleList, categoryLiteralList, singleArticleDetail, isMobile, blogName, thumbnail, description } = props;
   const { category } = useParams();
 
-  const blogImgProps = { description, thumbnail };
+  const blogImgProps = { blogName, description, thumbnail };
   const categoryName = decodeURI(category as string);
 
   const FilteredArticleList = articleList.filter(
@@ -72,7 +73,7 @@ const ArticleListWithThumbnail = (props: ArticleListWithThumbnailProps) => {
   };
 
   return (
-    <>
+    <MainContainer>
       {Thumbnail()}
       <CategoryBtnWrapper className={isMobile ? 'mobile' : ''} $thumbnail={thumbnail}>
         <CategoryBtnBar LiteralList={categoryLiteralList} isMobile={isMobile} />
@@ -80,12 +81,19 @@ const ArticleListWithThumbnail = (props: ArticleListWithThumbnailProps) => {
       <ArticleWrapper>
         <ArticleList articleList={category ? FilteredArticleList : articleList} isMobile={isMobile} />
       </ArticleWrapper>
-    </>
+    </MainContainer>
   );
 };
 
 export default ArticleListWithThumbnail;
 
+const MainContainer = styled.div`
+  padding: 0 4rem;
+  overflow-x: hidden;
+  @media (max-width: 768px) {
+    padding: 0 2rem;
+  }
+`;
 const ContentThumbnail = styled(Image)`
   border-radius: 1.6rem;
   object-fit: cover;
@@ -106,13 +114,12 @@ const ArticleWrapper = styled.section`
   align-items: center;
 
   margin-bottom: 11rem;
-  width: 100vw;
+  min-height: 50rem;
 `;
 
 const CategoryBtnWrapper = styled.div<{ $thumbnail: string | null }>`
   display: flex;
   justify-content: center;
-  width: 100vw;
 
   &.mobile {
     margin-top: ${({ $thumbnail }) => ($thumbnail ? 0 : '7.2rem')};

--- a/components/blog/ui/CategoryBtnBar.tsx
+++ b/components/blog/ui/CategoryBtnBar.tsx
@@ -65,70 +65,53 @@ const CategoryBtnBarContainer = styled.div`
   gap: 1.2rem;
   justify-content: flex-start;
   padding: 8rem 0 4.8rem;
-  width: 72rem;
+  width: 100%;
+  max-width: 124rem;
 
   &.mobile {
-    padding: 2.8rem 2.4rem 2.2rem;
+    padding: 2.8rem 0 2.2rem 0;
     width: 100%;
   }
 `;
 
-const CategoryBtn = styled(Link)`
-  ${({ theme }) => theme.fonts.Body1_Regular};
-
+const CategoryBtnDefault = styled(Link)`
   display: flex;
   align-items: center;
   justify-content: center;
-
   border: none;
-  border-radius: 4rem;
-
   background-color: ${({ theme }) => theme.colors.grey_300};
-  padding: 0 2rem;
-  height: 4.2rem;
-
   white-space: nowrap;
-
   color: ${({ theme }) => theme.colors.grey_700};
-
   &:hover {
     background-color: ${({ theme }) => theme.colors.grey_400};
   }
-
   &.selected {
-    ${({ theme }) => theme.fonts.Body1_Regular};
-
     background-color: ${({ theme }) => theme.colors.grey_900};
     color: ${({ theme }) => theme.colors.grey_0};
   }
 `;
 
-const MobileCategoryBtn = styled(Link)`
+const CategoryBtn = styled(CategoryBtnDefault)`
+  ${({ theme }) => theme.fonts.Body1_Regular};
+  border-radius: 1.4rem;
+
+  padding: 0 2rem;
+  height: 4.2rem;
+
+  &.selected {
+    ${({ theme }) => theme.fonts.Body1_Regular};
+  }
+`;
+
+const MobileCategoryBtn = styled(CategoryBtnDefault)`
   ${({ theme }) => theme.mobileFonts.Body2_Regular};
 
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  border-radius: 1.2rem;
 
-  border: none;
-  border-radius: 4rem;
-
-  background-color: ${({ theme }) => theme.colors.grey_300};
   padding: 0 1.5rem;
   height: 3.2rem;
 
-  white-space: nowrap;
-
-  color: ${({ theme }) => theme.colors.grey_700};
-
-  &:hover {
-    background-color: ${({ theme }) => theme.colors.grey_400};
-  }
-
   &.selected {
     ${({ theme }) => theme.mobileFonts.Body2_Semibold};
-
-    background-color: ${({ theme }) => theme.colors.grey_900};
-    color: ${({ theme }) => theme.colors.grey_0};
   }
 `;

--- a/components/blog/ui/CategoryBtnBar.tsx
+++ b/components/blog/ui/CategoryBtnBar.tsx
@@ -78,6 +78,7 @@ const CategoryBtnDefault = styled(Link)`
   display: flex;
   align-items: center;
   justify-content: center;
+  transition: 0.15s ease-in-out;
   border: none;
   background-color: ${({ theme }) => theme.colors.grey_300};
   white-space: nowrap;

--- a/components/common/Article.tsx
+++ b/components/common/Article.tsx
@@ -62,7 +62,7 @@ const ArticleThumbnailWrapperWrapper = styled.div`
 `;
 const ArticleThumbnailWrapper = styled.div`
   position: relative;
-  border-radius: 0.8rem;
+  border-radius: 1.2rem;
   padding-bottom: 60%;
   width: 100%;
   ${({ theme }) => theme.outlines.Transparent};
@@ -83,13 +83,13 @@ const ArticleMockThumbnail = styled.div`
   align-items: flex-end;
   justify-content: flex-start;
   border-radius: inherit;
-  background: ${({ theme }) => theme.colors.grey_300};
-  padding: 2.4rem;
+  background: ${({ theme }) => theme.colors.grey_800};
+  padding: 2.2rem 2.6rem;
   width: 100%;
   height: 100%;
   text-align: left;
   line-height: 1.5;
-  color: ${({ theme }) => theme.colors.grey_900};
+  color: ${({ theme }) => theme.colors.grey_0};
   font-family: 'Pretendard';
   font-size: 2rem;
   font-weight: 300;

--- a/components/common/Article.tsx
+++ b/components/common/Article.tsx
@@ -25,17 +25,29 @@ const Article = (props: ArticleProps) => {
   return (
     <>
       <ArticleContainer href={`/${articleUrl}`} className={noHover ? '' : 'hover'}>
+        <ArticleThumbnailContainer>
+          <ArticleThumbnailWrapper>
+            <ArticleThumbnailWrapperWrapper>
+              {thumbnail ? (
+                <ArticleThumbnail src={thumbnail} alt="Article Thumbnail" width={228} height={170} />
+              ) : (
+                <ArticleMockThumbnail>
+                  <div>{title}</div>
+                </ArticleMockThumbnail>
+              )}
+            </ArticleThumbnailWrapperWrapper>
+          </ArticleThumbnailWrapper>
+        </ArticleThumbnailContainer>
         <ArticleInfo $thumbnail={thumbnail ?? ''}>
-          <EditorInputTitle className="title">{title}</EditorInputTitle>
-          <ArticleDescription className="description">{description}</ArticleDescription>
           <DetailBox>
             {selectedCategory === 'home' && <CategoryBtn>{articleCategory.categoryName}</CategoryBtn>}
             <ArticleDetail>{memberName}</ArticleDetail>
             <Bar>|</Bar>
             <ArticleDetail>{createdAt}</ArticleDetail>
           </DetailBox>
+          <EditorInputTitle className="title">{title}</EditorInputTitle>
+          <ArticleDescription className="description">{description}</ArticleDescription>
         </ArticleInfo>
-        {thumbnail && <ArticleThumbnail src={thumbnail} alt="Article Thumbnail" width={228} height={170} />}
       </ArticleContainer>
     </>
   );
@@ -43,22 +55,78 @@ const Article = (props: ArticleProps) => {
 
 export default Article;
 
+const ArticleThumbnailWrapperWrapper = styled.div`
+  position: absolute;
+  inset: 0px;
+`;
+const ArticleThumbnailWrapper = styled.div`
+  position: relative;
+  padding-bottom: 60%;
+  width: 100%;
+`;
+const ArticleThumbnailContainer = styled.div`
+  position: relative;
+  border-radius: 8px;
+  width: 100%;
+  overflow: hidden;
+`;
 const ArticleThumbnail = styled(Image)`
-  border: 1px solid rgba(52, 58, 64, 0.1);
+  outline: 1px solid rgba(0, 0, 0, 0.08);
+  outline-offset: -1px;
   border-radius: 1.2rem;
-  width: 22.8rem;
-  height: 17rem;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
+`;
+const ArticleMockThumbnail = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  outline: 1px solid rgba(0, 0, 0, 0.08);
+  outline-offset: -1px;
+  background: ${({ theme }) => theme.colors.grey_900};
+  padding: 2.4rem;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  line-height: 1.5;
+  color: ${({ theme }) => theme.colors.grey_0};
+  font-family: 'Pretendard';
+  font-size: 2rem;
+  font-weight: 300;
 `;
 
 const ArticleContainer = styled(Link)`
   display: flex;
-  gap: 3.2rem;
-  justify-content: space-between;
+  position: relative;
+  flex-direction: column;
+  gap: 2rem;
+  justify-content: flex-start;
+  border-radius: 12px;
+  padding: 1.2rem 1.2rem 1.6rem 1.2rem;
 
   width: 100%;
 
-  &.hover {
+  &::before {
+    position: absolute;
+    top: 0;
+    left: 0;
+    transform: scale(0.97);
+    transition: 0.15s;
+    opacity: 0;
+    border-radius: inherit;
+    background-color: ${({ theme }) => theme.colors.grey_700};
+    width: 100%;
+    height: 100%;
+    content: '';
+    pointer-events: none;
+  }
+  &:hover::before {
+    transform: none;
+    opacity: 0.1;
+  }
+
+  /* &.hover {
     transform: translateY(0.8rem);
     transition: 0.3s ease-in-out;
   }
@@ -71,53 +139,56 @@ const ArticleContainer = styled(Link)`
     .description {
       opacity: 0.8;
     }
-  }
+  } */
 `;
 
 const ArticleInfo = styled.article<{ $thumbnail: string }>`
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  padding-top: 0.4rem;
-
-  width: ${({ $thumbnail }) => ($thumbnail ? '46rem' : '100%')};
 `;
 
 const EditorInputTitle = styled.article`
-  ${({ theme }) => theme.fonts.Heading2};
   /* stylelint-disable-next-line value-no-vendor-prefix */
   display: -webkit-box;
 
-  margin-bottom: 0.4rem;
+  margin-top: 1rem;
   width: 100%;
-
-  overflow: hidden;
-  text-overflow: ellipsis;
+  /* text-overflow: ellipsis; */
+  line-height: 1.5;
   white-space: wrap;
   word-break: keep-all;
 
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-
   color: ${({ theme }) => theme.colors.grey_900};
+  font-family: 'Pretendard';
+  /* ${({ theme }) => theme.fonts.Heading2}; */
+  font-size: 2rem;
+  font-weight: 600;
+
+  /* -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical; */
 `;
 
 const ArticleDescription = styled.div`
-  ${({ theme }) => theme.fonts.Body2_Regular};
+  /* ${({ theme }) => theme.fonts.Body2_Regular}; */
   /* stylelint-disable-next-line value-no-vendor-prefix */
   display: -webkit-box;
-
+  margin-top: 0.8rem;
   width: 100%;
-
-  overflow: hidden;
+  overflow-y: hidden;
   text-overflow: ellipsis;
+  line-height: 1.5;
   white-space: wrap;
   word-break: keep-all;
+  color: #8d96a1;
+  font-family: 'Pretendard';
 
-  -webkit-line-clamp: 2;
+  font-size: 1.4rem;
+
+  -webkit-line-clamp: 4;
   -webkit-box-orient: vertical;
 
-  color: ${({ theme }) => theme.colors.grey_900};
+  /* color: ${({ theme }) => theme.colors.grey_900}; */
 `;
 
 const ArticleDetail = styled.div`
@@ -137,9 +208,8 @@ const DetailBox = styled.div`
   display: flex;
   gap: 0.4rem;
   align-items: center;
-
-  margin-top: 1.7rem;
   width: 100%;
+  font-family: 'Pretendard';
 `;
 const CategoryBtn = styled.div`
   ${({ theme }) => theme.fonts.Body3_Regular};

--- a/components/common/Article.tsx
+++ b/components/common/Article.tsx
@@ -58,39 +58,38 @@ export default Article;
 const ArticleThumbnailWrapperWrapper = styled.div`
   position: absolute;
   inset: 0px;
+  border-radius: inherit;
 `;
 const ArticleThumbnailWrapper = styled.div`
   position: relative;
+  border-radius: 0.8rem;
   padding-bottom: 60%;
   width: 100%;
+  ${({ theme }) => theme.outlines.Transparent};
 `;
 const ArticleThumbnailContainer = styled.div`
   position: relative;
-  border-radius: 8px;
   width: 100%;
   overflow: hidden;
 `;
 const ArticleThumbnail = styled(Image)`
-  outline: 1px solid rgba(0, 0, 0, 0.08);
-  outline-offset: -1px;
-  border-radius: 1.2rem;
+  border-radius: inherit;
   width: 100%;
   height: 100%;
   object-fit: cover;
 `;
 const ArticleMockThumbnail = styled.div`
   display: flex;
-  align-items: center;
-  justify-content: center;
-  outline: 1px solid rgba(0, 0, 0, 0.08);
-  outline-offset: -1px;
-  background: ${({ theme }) => theme.colors.grey_900};
+  align-items: flex-end;
+  justify-content: flex-start;
+  border-radius: inherit;
+  background: ${({ theme }) => theme.colors.grey_300};
   padding: 2.4rem;
   width: 100%;
   height: 100%;
-  text-align: center;
+  text-align: left;
   line-height: 1.5;
-  color: ${({ theme }) => theme.colors.grey_0};
+  color: ${({ theme }) => theme.colors.grey_900};
   font-family: 'Pretendard';
   font-size: 2rem;
   font-weight: 300;

--- a/components/common/Article.tsx
+++ b/components/common/Article.tsx
@@ -97,8 +97,8 @@ const ArticleMockThumbnail = styled.div`
 `;
 
 const ArticleContainer = styled(Link)`
+  ${({ theme }) => theme.transitions.Expand};
   display: flex;
-  position: relative;
   flex-direction: column;
   gap: 2rem;
   justify-content: flex-start;
@@ -106,25 +106,6 @@ const ArticleContainer = styled(Link)`
   padding: 1.2rem 1.2rem 1.6rem 1.2rem;
 
   width: 100%;
-
-  &::before {
-    position: absolute;
-    top: 0;
-    left: 0;
-    transform: scale(0.97);
-    transition: 0.15s;
-    opacity: 0;
-    border-radius: inherit;
-    background-color: ${({ theme }) => theme.colors.grey_700};
-    width: 100%;
-    height: 100%;
-    content: '';
-    pointer-events: none;
-  }
-  &:hover::before {
-    transform: none;
-    opacity: 0.1;
-  }
 
   /* &.hover {
     transform: translateY(0.8rem);

--- a/components/common/ArticleList.tsx
+++ b/components/common/ArticleList.tsx
@@ -47,15 +47,22 @@ const ArticleList = (prop: ArticleListProp) => {
 export default ArticleList;
 
 const ArticleListContainer = styled.section`
-  display: flex;
-  flex-direction: column;
-  gap: 6rem;
-  width: 72rem;
-  min-height: 50rem;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-row-gap: 2.8rem;
+  grid-column-gap: 2.4rem;
+  width: calc(100% + 24px);
+  max-width: calc(124rem + 24px);
 
   &.mobile {
+    grid-template-columns: repeat(1, 1fr);
+    grid-row-gap: 6rem;
     align-items: center;
 
-    width: 100vw;
+    width: 100%;
+  }
+  @media (max-width: 1280px) {
+    grid-template-columns: repeat(2, 1fr);
+    grid-column-gap: 2rem;
   }
 `;

--- a/components/common/BlogFooter.tsx
+++ b/components/common/BlogFooter.tsx
@@ -29,18 +29,11 @@ const BlogFooter = (props: BlogFooterProps) => {
     );
   };
 
-  if (isMobile)
-    return (
-      <FooterContainer className={isMobile ? 'mobile' : ''}>
-        <MobileFooterWrap>{footerMain()}</MobileFooterWrap>
-      </FooterContainer>
-    );
-  else
-    return (
-      <FooterContainer>
-        <FooterWrapper>{footerMain()}</FooterWrapper>
-      </FooterContainer>
-    );
+  return (
+    <FooterContainer className={isMobile ? 'mobile' : ''}>
+      <FooterWrapper>{footerMain()}</FooterWrapper>
+    </FooterContainer>
+  );
 };
 
 export default BlogFooter;
@@ -60,11 +53,7 @@ const FooterWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  width: 72rem;
-`;
-
-const MobileFooterWrap = styled(FooterWrapper)`
-  padding: 0 2rem;
+  width: 124rem;
 `;
 
 const CompanyName = styled.p`
@@ -100,10 +89,10 @@ const FooterContainer = styled.div`
   border-top: 1px solid ${({ theme }) => theme.colors.grey_300};
   background: #fafafa;
 
-  padding: 7.2rem 0 8.4rem 0;
+  padding: 7.2rem 2rem 8.4rem 2rem;
   width: 100%;
   &.mobile {
-    padding: 4rem 0 7.2rem 0;
+    padding: 4rem 2rem 7.2rem 2rem;
   }
 `;
 

--- a/components/common/BlogFooter.tsx
+++ b/components/common/BlogFooter.tsx
@@ -42,7 +42,7 @@ const MadeWithPalms = styled.p`
   cursor: default;
   line-height: normal;
   letter-spacing: -0.005rem;
-  color: #8c8c8c;
+  color: ${({ theme }) => theme.colors.grey_700};
   font-family: 'Pretendard';
   font-size: 1.2rem;
   font-weight: 400;
@@ -73,7 +73,7 @@ const CompanyDetail = styled.p`
   letter-spacing: -0.005rem;
   white-space: pre-line;
 
-  color: #8c8c8c;
+  color: ${({ theme }) => theme.colors.grey_700};
   font-family: 'Pretendard';
   font-size: 1.3rem;
   font-weight: 400;
@@ -87,7 +87,7 @@ const FooterContainer = styled.div`
   justify-content: center;
   margin-top: 4rem;
   border-top: 1px solid ${({ theme }) => theme.colors.grey_300};
-  background: #fafafa;
+  background: ${({ theme }) => theme.colors.grey_100};
 
   padding: 7.2rem 2rem 8.4rem 2rem;
   width: 100%;
@@ -100,7 +100,7 @@ const LandingPageLink = styled(Link)`
   text-decoration: underline;
   line-height: normal;
   letter-spacing: -0.005rem;
-  color: #8c8c8c;
+  color: ${({ theme }) => theme.colors.grey_700};
   font-family: 'Pretendard';
   font-size: 1.2rem;
   font-weight: 400;

--- a/components/common/BlogHeader.tsx
+++ b/components/common/BlogHeader.tsx
@@ -35,18 +35,22 @@ const BlogHeader = (props: HeaderProps) => {
 
   if (isMobile)
     return (
-      <BlogHeaderContainer className="mobile" $ifscrollpositionzero={ifScrollPositionZero}>
-        <HeaderLogo logo={logo} blogName={blogName} />
-        <BlurBackground className={isMenuOpen ? 'blur' : ''} onClick={sidebarToggle} />
-        <SideBar isMenuOpen={isMenuOpen} setIsMenuOpen={setIsMenuOpen} navList={navList} />
-        <MenuIcon type="button" onClick={sidebarToggle} />
+      <BlogHeaderContainer $ifscrollpositionzero={ifScrollPositionZero}>
+        <BlogHeaderWrapper className="mobile">
+          <HeaderLogo logo={logo} blogName={blogName} />
+          <BlurBackground className={isMenuOpen ? 'blur' : ''} onClick={sidebarToggle} />
+          <SideBar isMenuOpen={isMenuOpen} setIsMenuOpen={setIsMenuOpen} navList={navList} />
+          <MenuIcon type="button" onClick={sidebarToggle} />
+        </BlogHeaderWrapper>
       </BlogHeaderContainer>
     );
   else
     return (
       <BlogHeaderContainer $ifscrollpositionzero={ifScrollPositionZero}>
-        <HeaderLogo logo={logo} blogName={blogName} />
-        <BlogNav blogName={blogName} navList={navList} />
+        <BlogHeaderWrapper>
+          <HeaderLogo logo={logo} blogName={blogName} />
+          <BlogNav blogName={blogName} navList={navList} />
+        </BlogHeaderWrapper>
       </BlogHeaderContainer>
     );
 };
@@ -72,18 +76,24 @@ const BlogHeaderContainer = styled.div<{ $ifscrollpositionzero: boolean }>`
   position: fixed;
   top: 0;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   transition: height 300ms cubic-bezier(0.31, 0.27, 0.15, 0.99) 0s;
   z-index: 10;
   border-bottom: 1px solid ${({ theme }) => theme.colors.grey_300};
 
   background: ${({ theme }) => theme.colors.grey_0};
-  padding: 0 max(calc((100vw - 100rem) / 2), 2.4rem);
   width: 100vw;
-  min-width: 72rem;
   height: 6rem;
   ${({ $ifscrollpositionzero }) => $ifscrollpositionzero && `height:7.2rem;border-color:transparent;`}
+`;
 
+const BlogHeaderWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 4rem;
+  width: 100%;
+  max-width: 144rem;
   &.mobile {
     padding: 0 1.6rem 0 2.4rem;
     min-width: 0;

--- a/components/common/ContentInfo.tsx
+++ b/components/common/ContentInfo.tsx
@@ -120,6 +120,7 @@ export default ContentInfo;
 const WriterBox = styled.article`
   display: flex;
   align-items: center;
+  transition: 0.15s ease-in-out;
 
   &:hover {
     opacity: 0.8;

--- a/components/common/MobileArticle.tsx
+++ b/components/common/MobileArticle.tsx
@@ -27,14 +27,14 @@ const MobileArticle = (props: ArticleProps) => {
         </ArticleThumbnailContainer>
       )}
       <ArticleInfo>
-        <EditorInputTitle>{title}</EditorInputTitle>
-        <ArticleDescription>{description}</ArticleDescription>
         <DetailBox>
           {selectedCategory === 'home' && <CategoryBtn type="button">{articleCategory.categoryName}</CategoryBtn>}
           <ArticleDetail>{memberName}</ArticleDetail>
           <Bar>|</Bar>
           <ArticleDetail>{createdAt}</ArticleDetail>
         </DetailBox>
+        <EditorInputTitle>{title}</EditorInputTitle>
+        <ArticleDescription>{description}</ArticleDescription>
       </ArticleInfo>
     </ArticleContainer>
   );
@@ -44,8 +44,8 @@ export default MobileArticle;
 
 const ArticleThumbnailContainer = styled.div`
   position: relative;
-  margin-bottom: 1.2rem;
-  width: calc(100vw - 4.8rem);
+  margin-bottom: 1.4rem;
+  width: 100%;
 
   height: calc((100vw - 4.8rem) * 9 / 16);
 `;
@@ -61,7 +61,7 @@ const ArticleContainer = styled(Link)`
   align-items: flex-start;
   justify-content: center;
 
-  width: calc(100vw - 4.8rem);
+  width: 100%;
 `;
 
 const ArticleInfo = styled.article`
@@ -76,11 +76,10 @@ const EditorInputTitle = styled.article`
   ${({ theme }) => theme.mobileFonts.Title2};
   /* stylelint-disable-next-line value-no-vendor-prefix */
   display: -webkit-box;
-
-  margin-bottom: 0.4rem;
-
+  margin-top: 0.8rem;
   overflow: hidden;
   text-overflow: ellipsis;
+  line-height: 1.5;
   white-space: wrap;
   word-break: keep-all;
 
@@ -88,6 +87,9 @@ const EditorInputTitle = styled.article`
   -webkit-box-orient: vertical;
 
   color: ${({ theme }) => theme.colors.grey_900};
+
+  font-size: 2rem;
+  font-weight: 600;
 `;
 
 const ArticleDescription = styled.div`
@@ -95,15 +97,19 @@ const ArticleDescription = styled.div`
   /* stylelint-disable-next-line value-no-vendor-prefix */
   display: -webkit-box;
 
+  margin-top: 0.6rem;
   overflow: hidden;
   text-overflow: ellipsis;
+  line-height: 1.5;
   white-space: wrap;
   word-break: keep-all;
 
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 
-  color: ${({ theme }) => theme.colors.grey_900};
+  color: #8d96a1;
+  font-size: 1.4rem;
+  font-weight: 400;
 `;
 
 const ArticleDetail = styled.div`
@@ -123,8 +129,6 @@ const DetailBox = styled.div`
   display: flex;
   gap: 0.4rem;
   align-items: center;
-
-  margin-top: 1rem;
 `;
 
 const CategoryBtn = styled.button`

--- a/components/content/ui/ArticleBox.tsx
+++ b/components/content/ui/ArticleBox.tsx
@@ -30,10 +30,14 @@ const ArticleBoxContainer = styled.section`
   grid-template-columns: repeat(2, 1fr);
   grid-row-gap: 2.8rem;
   grid-column-gap: 2.4rem;
-  width: 100%;
+  margin-left: -1.2rem;
+  width: calc(100% + 2.4rem);
 
   &.mobile {
     grid-template-columns: repeat(1, 1fr);
+    margin-top: 1.4rem;
+    margin-left: unset;
+    width: 100%;
   }
 
   @media (max-width: 1280px) {

--- a/components/content/ui/ArticleBox.tsx
+++ b/components/content/ui/ArticleBox.tsx
@@ -26,10 +26,18 @@ const ArticleBox = (props: ArticleBoxProps) => {
 export default ArticleBox;
 
 const ArticleBoxContainer = styled.section`
-  display: flex;
-  flex-direction: column;
-  gap: 6rem;
-  align-items: center;
-
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-row-gap: 2.8rem;
+  grid-column-gap: 2.4rem;
   width: 100%;
+
+  &.mobile {
+    grid-template-columns: repeat(1, 1fr);
+  }
+
+  @media (max-width: 1280px) {
+    grid-template-columns: repeat(2, 1fr);
+    grid-row-gap: 6rem;
+  }
 `;

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -126,6 +126,7 @@ const fonts = {
     font-style: normal;
   `,
   Button_large: css`
+    transition: 0.2s ease-in-out;
     letter-spacing: -0.0025em;
     font-family: 'Pretendard';
     font-size: 1.8rem;
@@ -134,6 +135,7 @@ const fonts = {
   `,
 
   Button_medium: css`
+    transition: 0.2s ease-in-out;
     letter-spacing: -0.003125em;
     font-family: 'Pretendard';
     font-size: 1.6rem;
@@ -141,6 +143,7 @@ const fonts = {
     font-style: normal;
   `,
   Button_small: css`
+    transition: 0.2s ease-in-out;
     letter-spacing: -0.00375em;
     font-family: 'Pretendard';
     font-size: 1.4rem;
@@ -281,10 +284,35 @@ const mobileFonts = {
   `,
 };
 
-const theme: Pick<DefaultTheme, 'colors' | 'fonts' | 'editor' | 'mobileFonts'> = {
+const transitions = {
+  Expand: css`
+    position: relative;
+    &::before {
+      position: absolute;
+      top: 0;
+      left: 0;
+      transform: scale(0.97);
+      transition: 0.15s;
+      opacity: 0;
+      border-radius: inherit;
+      background-color: ${({ theme }) => theme.colors.grey_700};
+      width: 100%;
+      height: 100%;
+      content: '';
+      pointer-events: none;
+    }
+    &:hover::before {
+      transform: none;
+      opacity: 0.1;
+    }
+  `,
+};
+
+const theme: Pick<DefaultTheme, 'colors' | 'fonts' | 'editor' | 'mobileFonts' | 'transitions'> = {
   colors,
   fonts,
   editor,
   mobileFonts,
+  transitions,
 };
 export default theme;

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -284,6 +284,23 @@ const mobileFonts = {
   `,
 };
 
+const outlines = {
+  Transparent: css`
+    position: relative;
+    &::after {
+      position: absolute;
+      top: 0;
+      left: 0;
+      outline: 1px solid rgba(0, 0, 0, 0.08);
+      outline-offset: -1px;
+      border-radius: inherit;
+      width: 100%;
+      height: 100%;
+      content: '';
+    }
+  `,
+};
+
 const transitions = {
   Expand: css`
     position: relative;
@@ -308,11 +325,12 @@ const transitions = {
   `,
 };
 
-const theme: Pick<DefaultTheme, 'colors' | 'fonts' | 'editor' | 'mobileFonts' | 'transitions'> = {
+const theme: Pick<DefaultTheme, 'colors' | 'fonts' | 'editor' | 'mobileFonts' | 'transitions' | 'outlines'> = {
   colors,
   fonts,
   editor,
   mobileFonts,
   transitions,
+  outlines,
 };
 export default theme;


### PR DESCRIPTION
슬랙에서 말씀드렸던 대로 블로그 메인 스타일 개선을 완료했습니다.

서현 명지 시연이 접때 말씀해주셨던 것처럼 기존 디자인시스템( 다시 말해 theme)을 최대한 활용해보려 했으나,
기존의 theme 자체가 마음에 들지 않아서 바꾸는 것도 있기 떄문에, 각 sc 내에서 color와 font size, weight 등을 직접 설정한 경우가 많습니다. 이 부분에 대해서는 양해를 부탁드리고 싶습니다.

또한 미디어쿼리를 따로 사용하지 않으시고 mobile check hook을 사용하고 계시다는 걸 알고 있습니다만 태블릿 width에 분기처리가 필요해서 부득이하게 최소한으로 미디어쿼리를 사용했습니다. hook의 리턴값 자체를 바꾸기에는 공수가 너무 커져서요...

수정된 화면 
- 블로그 메인의 홈화면
- 블로그 내 각 author별 화면
- 이외에도 header, footer, 각 container의 padding값 등 세부 스타일이 수정됨